### PR TITLE
Gm/textfield features

### DIFF
--- a/MudBlazor.Forms/Code/AeModelFormTools.cs
+++ b/MudBlazor.Forms/Code/AeModelFormTools.cs
@@ -151,6 +151,8 @@ namespace MudBlazor.Forms
             }
             if (includeOptional && !IsRequired(propertyInfo))
                 return label + " (Optional)";
+            if (IsRequired(propertyInfo))
+                return label + "*";
             return label;
         }
 

--- a/MudBlazor.Forms/Code/AeModelFormTools.cs
+++ b/MudBlazor.Forms/Code/AeModelFormTools.cs
@@ -149,10 +149,6 @@ namespace MudBlazor.Forms
                     label = Labelize(propertyInfo.Name);
                 }
             }
-            if (includeOptional && !IsRequired(propertyInfo))
-                return label + " (Optional)";
-            if (IsRequired(propertyInfo))
-                return label + "*";
             return label;
         }
 

--- a/MudBlazor.Forms/Code/ModelFormContext.cs
+++ b/MudBlazor.Forms/Code/ModelFormContext.cs
@@ -47,7 +47,7 @@ namespace MudBlazor.Forms
         public List<PropertyInfo> Properties { get; private set; }
 
         public List<(string category, List<List<PropertyInfo>> properties)> GetCategories() =>
-            typeof(T).GetMudModelFormCategories().Select(elem => (string.IsNullOrWhiteSpace(elem.category) ? "Uncategorized" : elem.category,
+            typeof(T).GetMudModelFormCategories().Select(elem => (string.IsNullOrWhiteSpace(elem.category) ? string.Empty : elem.category,
                     visibleProperties: elem.properties.Select(l => l.Where(l => IsVisible(l)).ToList()).ToList()))
                     .Where(p => p.visibleProperties.Any(l => l.Count > 0)).ToList();
 

--- a/MudBlazor.Forms/Internal/MudFormsStringPropertyInput.razor
+++ b/MudBlazor.Forms/Internal/MudFormsStringPropertyInput.razor
@@ -3,56 +3,36 @@
 @using Microsoft.AspNetCore.Components.Forms
 @namespace MudBlazor.Forms
 
-@if (!PropertyInfo.IsEditable())
+@if(MudModelFormTools.IsPasswordField(PropertyInfo))
 {
-    @if (MudModelFormTools.IsNumericType(PropertyInfo.PropertyType))
-    {
-        <MudTextField ReadOnly="true" InputType="@TextFieldType" Variant="Variant.Filled" HelperText="@_fieldNotes"
-                      @key="PropertyInfo.Name" @bind-Value="PropertyValue"
-                      Label="@GetLabel()" For="@(MudModelFormTools.GetExpression<string>(Instance, PropertyInfo))">
-            @GetFormattedValue()
-        </MudTextField>
-    }
-    else
-    {
-        <MudTextField ReadOnly="true" InputType="@TextFieldType" Variant="Variant.Filled" HelperText="@_fieldNotes"
-                      @key="PropertyInfo.Name" @bind-Value="PropertyValue"
-                      Label="@GetLabel()" For="@(MudModelFormTools.GetExpression<string>(Instance, PropertyInfo))">
-            @GetFormattedValue()
-        </MudTextField>
-    }
+    <MudTextField @key="PropertyInfo.Name"
+            @bind-Value="PropertyValue"
+            InputType="@PasswordInput"
+            ReadOnly=!PropertyInfo.IsEditable()
+            Label="@GetLabel()"
+            Variant="Variant.Text"
+            Placeholder="@localize(MudModelFormTools.GetPlaceHolder(PropertyInfo))"
+            Lines="@(MudModelFormTools.GetLineCount(PropertyInfo) ?? 1)"
+            Adornment="Adornment.End" AdornmentIcon="@PasswordInputIcon" AdornmentAriaLabel="Show/Hide Password"
+            OnAdornmentClick="ToggleViewPassword" 
+            MaxLength="@(MudModelFormTools.GetSize(PropertyInfo) ?? 524288)"
+            For="@(MudModelFormTools.GetExpression<string>(Instance, PropertyInfo))"
+            HelperText="@_fieldNotes" />
 }
 else
 {
-    @if(MudModelFormTools.IsPasswordField(PropertyInfo))
-    {
-        <MudTextField @key="PropertyInfo.Name"
-              @bind-Value="PropertyValue"
-              InputType="@PasswordInput"
-              Label="@GetLabel()"
-              Variant="Variant.Text"
-              Placeholder="@localize(MudModelFormTools.GetPlaceHolder(PropertyInfo))"
-              Lines="@(MudModelFormTools.GetLineCount(PropertyInfo) ?? 1)"
-              Adornment="Adornment.End" AdornmentIcon="@PasswordInputIcon" AdornmentAriaLabel="Show/Hide Password"
-              OnAdornmentClick="ToggleViewPassword" 
-              MaxLength="@(MudModelFormTools.GetSize(PropertyInfo) ?? 524288)"
-              For="@(MudModelFormTools.GetExpression<string>(Instance, PropertyInfo))"
-              HelperText="@_fieldNotes" />
-    }
-    else
-    {
-        <MudTextField @key="PropertyInfo.Name" 
-            @bind-Value="PropertyValue" 
-            InputType="@TextFieldType"
-            Label="@GetLabel()" 
-            Variant="Variant.Text"
-            Placeholder="@localize(MudModelFormTools.GetPlaceHolder(PropertyInfo))" 
-            Lines="@(MudModelFormTools.GetLineCount(PropertyInfo) ?? 1)"
-            MaxLength="@(MudModelFormTools.GetSize(PropertyInfo) ?? 524288)"
-            For="@(MudModelFormTools.GetExpression<string>(Instance, PropertyInfo))"
-            HelperText="@_fieldNotes"
-            />
-    }
+    <MudTextField @key="PropertyInfo.Name" 
+        @bind-Value="PropertyValue" 
+        InputType="@TextFieldType"
+        ReadOnly=!PropertyInfo.IsEditable()
+        Label="@GetLabel()" 
+        Variant="Variant.Text"
+        Placeholder="@localize(MudModelFormTools.GetPlaceHolder(PropertyInfo))" 
+        Lines="@(MudModelFormTools.GetLineCount(PropertyInfo) ?? 1)"
+        MaxLength="@(MudModelFormTools.GetSize(PropertyInfo) ?? 524288)"
+        For="@(MudModelFormTools.GetExpression<string>(Instance, PropertyInfo))"
+        HelperText="@_fieldNotes"
+        />
 }
 
 @code {

--- a/MudBlazor.Forms/Internal/MudFormsStringPropertyInput.razor
+++ b/MudBlazor.Forms/Internal/MudFormsStringPropertyInput.razor
@@ -6,18 +6,19 @@
 @if(MudModelFormTools.IsPasswordField(PropertyInfo))
 {
     <MudTextField @key="PropertyInfo.Name"
-            @bind-Value="PropertyValue"
-            InputType="@PasswordInput"
-            ReadOnly=!PropertyInfo.IsEditable()
-            Label="@GetLabel()"
-            Variant="Variant.Text"
-            Placeholder="@localize(MudModelFormTools.GetPlaceHolder(PropertyInfo))"
-            Lines="@(MudModelFormTools.GetLineCount(PropertyInfo) ?? 1)"
-            Adornment="Adornment.End" AdornmentIcon="@PasswordInputIcon" AdornmentAriaLabel="Show/Hide Password"
-            OnAdornmentClick="ToggleViewPassword" 
-            MaxLength="@(MudModelFormTools.GetSize(PropertyInfo) ?? 524288)"
-            For="@(MudModelFormTools.GetExpression<string>(Instance, PropertyInfo))"
-            HelperText="@_fieldNotes" />
+        @bind-Value="PropertyValue"
+        InputType="@PasswordInput"
+        ReadOnly=!PropertyInfo.IsEditable()
+        Class="@RequiredClass"
+        Label="@GetLabel()"
+        Variant="Variant.Text"
+        Placeholder="@localize(MudModelFormTools.GetPlaceHolder(PropertyInfo))"
+        Lines="@(MudModelFormTools.GetLineCount(PropertyInfo) ?? 1)"
+        Adornment="Adornment.End" AdornmentIcon="@PasswordInputIcon" AdornmentAriaLabel="Show/Hide Password"
+        OnAdornmentClick="ToggleViewPassword" 
+        MaxLength="@(MudModelFormTools.GetSize(PropertyInfo) ?? 524288)"
+        For="@(MudModelFormTools.GetExpression<string>(Instance, PropertyInfo))"
+        HelperText="@_fieldNotes" />
 }
 else
 {
@@ -25,6 +26,7 @@ else
         @bind-Value="PropertyValue" 
         InputType="@TextFieldType"
         ReadOnly=!PropertyInfo.IsEditable()
+        Class="@RequiredClass"
         Label="@GetLabel()" 
         Variant="Variant.Text"
         Placeholder="@localize(MudModelFormTools.GetPlaceHolder(PropertyInfo))" 
@@ -34,6 +36,16 @@ else
         HelperText="@_fieldNotes"
         />
 }
+
+<style>
+    .label-required .mud-input-label::after {
+        color: #e53e3e;
+        content: "*";
+    }
+    .label-optional .mud-input-label::after {
+        content: "";
+    }
+</style>
 
 @code {
 
@@ -58,6 +70,10 @@ else
     [CascadingParameter(Name = "ModelFormContext")]
     public ModelFormContext<T> ModelFormContext { get; set; } = null;
 
+    private bool IsRequired => MudModelFormTools.IsRequired(PropertyInfo);
+
+    private string RequiredClass => IsRequired ? "label-required" : "label-optional";
+
     private string? _fieldNotes;
 
     private bool showPassword = false;
@@ -66,7 +82,7 @@ else
 
     void ToggleViewPassword()
     {
-        @if (showPassword)
+    @if (showPassword)
         {
             showPassword = false;
             PasswordInputIcon = Icons.Material.Filled.VisibilityOff;

--- a/MudBlazor.Forms/Internal/MudFormsStringPropertyInput.razor
+++ b/MudBlazor.Forms/Internal/MudFormsStringPropertyInput.razor
@@ -24,33 +24,35 @@
 }
 else
 {
-        @if (MudModelFormTools.GetLineCount(PropertyInfo) is null)
-        {
-            <MudTextField @key="PropertyInfo.Name"
-                          @bind-Value="PropertyValue" 
-                          InputType="@TextFieldType"
-                          Label="@GetLabel()"
-                          Placeholder="@localize(MudModelFormTools.GetPlaceHolder(PropertyInfo))"
-                          MaxLength="@(MudModelFormTools.GetSize(PropertyInfo) ?? 524288)"
-                          For="@(MudModelFormTools.GetExpression<string>(Instance, PropertyInfo))"
-                          HelperText="@_fieldNotes"
-                          />
-           
-        }
-        else
-        {
-            <MudTextField @key="PropertyInfo.Name" 
-                          @bind-Value="PropertyValue" 
-                          InputType="@TextFieldType"
-                          Label="@GetLabel()" 
-                          Variant="Variant.Text"
-                          Placeholder="@localize(MudModelFormTools.GetPlaceHolder(PropertyInfo))" 
-                          Lines="@(MudModelFormTools.GetLineCount(PropertyInfo) ?? 3)"
-                          MaxLength="@(MudModelFormTools.GetSize(PropertyInfo) ?? 524288)"
-                          For="@(MudModelFormTools.GetExpression<string>(Instance, PropertyInfo))"
-                          HelperText="@_fieldNotes"
-                          />
-        }
+    @if(MudModelFormTools.IsPasswordField(PropertyInfo))
+    {
+        <MudTextField @key="PropertyInfo.Name"
+              @bind-Value="PropertyValue"
+              InputType="@PasswordInput"
+              Label="@GetLabel()"
+              Variant="Variant.Text"
+              Placeholder="@localize(MudModelFormTools.GetPlaceHolder(PropertyInfo))"
+              Lines="@(MudModelFormTools.GetLineCount(PropertyInfo) ?? 1)"
+              Adornment="Adornment.End" AdornmentIcon="@PasswordInputIcon" AdornmentAriaLabel="Show/Hide Password"
+              OnAdornmentClick="ToggleViewPassword" 
+              MaxLength="@(MudModelFormTools.GetSize(PropertyInfo) ?? 524288)"
+              For="@(MudModelFormTools.GetExpression<string>(Instance, PropertyInfo))"
+              HelperText="@_fieldNotes" />
+    }
+    else
+    {
+        <MudTextField @key="PropertyInfo.Name" 
+            @bind-Value="PropertyValue" 
+            InputType="@TextFieldType"
+            Label="@GetLabel()" 
+            Variant="Variant.Text"
+            Placeholder="@localize(MudModelFormTools.GetPlaceHolder(PropertyInfo))" 
+            Lines="@(MudModelFormTools.GetLineCount(PropertyInfo) ?? 1)"
+            MaxLength="@(MudModelFormTools.GetSize(PropertyInfo) ?? 524288)"
+            For="@(MudModelFormTools.GetExpression<string>(Instance, PropertyInfo))"
+            HelperText="@_fieldNotes"
+            />
+    }
 }
 
 @code {
@@ -77,6 +79,26 @@ else
     public ModelFormContext<T> ModelFormContext { get; set; } = null;
 
     private string? _fieldNotes;
+
+    private bool showPassword = false;
+    InputType PasswordInput = InputType.Password;
+    string PasswordInputIcon = Icons.Material.Filled.VisibilityOff;
+
+    void ToggleViewPassword()
+    {
+        @if (showPassword)
+        {
+            showPassword = false;
+            PasswordInputIcon = Icons.Material.Filled.VisibilityOff;
+            PasswordInput = InputType.Password;
+        }
+        else
+        {
+            showPassword = true;
+            PasswordInputIcon = Icons.Material.Filled.Visibility;
+            PasswordInput = InputType.Text;
+        }
+    }
 
     private string localize(string input)
     {


### PR DESCRIPTION
## Description
Resolves #8, Resolves #9, Resolves #10 

- Added simple logic to toggle visibility of a password field when user clicks on the field's adornment. 
- Added asterisk next to required fields
- Replaced "Uncategorized" title with an empty string if the element has no category

### Screenshots
![image](https://user-images.githubusercontent.com/60167780/202296581-62d1473b-f917-4d47-964b-0f756a0c4843.png)
![image](https://user-images.githubusercontent.com/60167780/202296770-b3c03425-64fe-4220-94f7-3fef45f7d9ad.png)
